### PR TITLE
Fixed Number conversion bug

### DIFF
--- a/parse/parse_tool.ls
+++ b/parse/parse_tool.ls
@@ -73,13 +73,13 @@ getConversations = (parsed,authToken) ->
       console.log participant.name
 
       p = [
-        Number participant.id
+        participant.id
         participant.name
       ]
 
       u = [
-        Number convoID
-        Number participant.id
+        convoID
+        participant.id
       ]
 
       participants.push p
@@ -98,8 +98,8 @@ parseMessages = (parsed,convoID) ->
     sender = comment.from.id
     message = [
       comment.id
-      Number convoID
-      Number sender
+      convoID
+      sender
       comment.message
       comment.created_time
     ]


### PR DESCRIPTION
@JakeSi @andysctu 

Removed casting to number, causes wrong ids for users to be persisted into the DB

```
> Number("10152124628327105")
< 10152124628327104
> parseInt("10152124628327105")
< 10152124628327104
```
